### PR TITLE
fix: update cuda version in installation

### DIFF
--- a/docs/01-getting-started/01-installation/01-gpu.md
+++ b/docs/01-getting-started/01-installation/01-gpu.md
@@ -8,7 +8,7 @@ vLLM 是一个支持如下 GPU 类型的 Python 库，根据您的 GPU 型号查
 
 ## NVIDIA CUDA
 
-vLLM 包含预编译的 C++ 和 CUDA (12.1) 二进制库。
+vLLM 包含预编译的 C++ 和 CUDA (12.8/12.6/11.8) 二进制库。
 
 ## AMD ROCm
 


### PR DESCRIPTION
1. vllm官方文档提供的cuda适配版本为12.8/12.6/11.8，详见 https://docs.vllm.ai/en/latest/getting_started/installation/gpu.html#pre-built-wheels 
2. 本人实测在cuda 12.1环境无法顺利安装vllm，切换至12.6才完成了安装
![image](https://github.com/user-attachments/assets/6ebe27e5-2a0f-4de9-a77e-ff65bbde8591)
